### PR TITLE
Update clouds.cfg

### DIFF
--- a/GameData/OPMVolumetricClouds/Clouds/clouds.cfg
+++ b/GameData/OPMVolumetricClouds/Clouds/clouds.cfg
@@ -592,9 +592,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 4681565
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 2381565
 			receivedShadowsDensity = 10
 			raymarchingSettings
 			{
@@ -737,9 +737,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 4681565
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 2381565
 			receivedShadowsDensity = 10
 			raymarchingSettings
 			{
@@ -879,9 +879,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 4681565
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 2381565
 			receiveShadowsFromLayer = Sarnus-clouds2
 			receivedShadowsDensity = 10
 			raymarchingSettings
@@ -1047,9 +1047,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 4681565
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 2381565
 			receiveShadowsFromLayer = 0
 			receivedShadowsDensity = 0
 			raymarchingSettings
@@ -1283,9 +1283,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 1922975
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 1692975
 			receivedShadowsDensity = 10
 			raymarchingSettings
 			{
@@ -1428,9 +1428,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 1922975
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 1692975
 			receivedShadowsDensity = 10
 			raymarchingSettings
 			{
@@ -1570,9 +1570,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 1922975
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 1692975
 			receiveShadowsFromLayer = Urlum-clouds2
 			receivedShadowsDensity = 10
 			raymarchingSettings
@@ -1738,9 +1738,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 1922975
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 1692975
 			receiveShadowsFromLayer = 0
 			receivedShadowsDensity = 0
 			raymarchingSettings
@@ -1974,9 +1974,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 1894709
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 1664709
 			receivedShadowsDensity = 10
 			raymarchingSettings
 			{
@@ -2119,9 +2119,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 1894709
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 1664709
 			receivedShadowsDensity = 10
 			raymarchingSettings
 			{
@@ -2261,9 +2261,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 1894709
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 1664709
 			receiveShadowsFromLayer = Neidon-clouds2
 			receivedShadowsDensity = 10
 			raymarchingSettings
@@ -2429,9 +2429,9 @@ EVE_CLOUDS
 		{
 			color = 50, 50, 50 255
 			upwardsCloudSpeed = 5
-			scaledFadeEndAltitude = 5300000
+			scaledFadeEndAltitude = 1894709
 			detailNoiseTiling = 15000
-			scaledFadeStartAltitude = 3000000
+			scaledFadeStartAltitude = 1664709
 			receiveShadowsFromLayer = 0
 			receivedShadowsDensity = 0
 			raymarchingSettings


### PR DESCRIPTION
Makes it so that the clouds don't appear so high up on the gas giants, as before they all used Jool's values. Now they use their own.